### PR TITLE
v1.1.4

### DIFF
--- a/custom_components/meinvodafone/__init__.py
+++ b/custom_components/meinvodafone/__init__.py
@@ -45,10 +45,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         COORDINATOR: coordinator,
     }
 
-    for platform in PLATFORMS:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(config_entry, platform)
-        )
+    await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
 
     return True
 


### PR DESCRIPTION
Fix warning introduced in HA 2024.7 (https://developers.home-assistant.io/blog/2024/06/12/async_forward_entry_setups/)