### PR TITLE
Feature/add callya support

### DIFF
--- a/custom_components/meinvodafone/MeinVodafoneAPI.py
+++ b/custom_components/meinvodafone/MeinVodafoneAPI.py
@@ -200,12 +200,19 @@ class MeinVodafoneAPI:
                             if container_name:
                                 aggregation = usage_data.get("vluxgateAgg")
                                 if aggregation:
+                                    last_update_time = None
+                                    usage_details = usage_data.get("usage", [])
+                                    if usage_details:
+                                        last_update_time = usage_details[0].get(
+                                            "lastUpdateDate"
+                                        )
+
                                     data = {
                                         NAME: aggregation.get("name"),
                                         REMAINING: aggregation.get("aggregateRemaining"),
                                         USED: aggregation.get("aggregateUsed"),
                                         TOTAL: aggregation.get("aggregateTotal"),
-                                        LAST_UPDATE: None,
+                                        LAST_UPDATE: last_update_time,
                                     }
                                     contract_usage_data[container_name].append(data)
                                 else:

--- a/custom_components/meinvodafone/MeinVodafoneContract.py
+++ b/custom_components/meinvodafone/MeinVodafoneContract.py
@@ -95,9 +95,7 @@ class MeinVodafoneContract:
     @property
     def minutes_remaining_last_update(self):
         """Return remaining minutes for the plan last update timestamp."""
-        return datetime.datetime.strptime(
-            self.get_value(MINUTES, LAST_UPDATE), "%Y-%m-%dT%H:%M:%S"
-        ).replace(tzinfo=datetime.UTC)
+        return datetime.datetime.fromisoformat(self.get_value(MINUTES, LAST_UPDATE))
 
     @property
     def is_minutes_remaining_supported(self):
@@ -115,9 +113,7 @@ class MeinVodafoneContract:
     @property
     def minutes_used_last_update(self):
         """Return used minutes for the plan last update timestamp."""
-        return datetime.datetime.strptime(
-            self.get_value(MINUTES, LAST_UPDATE), "%Y-%m-%dT%H:%M:%S"
-        ).replace(tzinfo=datetime.UTC)
+        return datetime.datetime.fromisoformat(self.get_value(MINUTES, LAST_UPDATE))
 
     @property
     def is_minutes_used_supported(self):
@@ -135,9 +131,7 @@ class MeinVodafoneContract:
     @property
     def minutes_total_last_update(self):
         """Return total minutes for the plan last update timestamp."""
-        return datetime.datetime.strptime(
-            self.get_value(MINUTES, LAST_UPDATE), "%Y-%m-%dT%H:%M:%S"
-        ).replace(tzinfo=datetime.UTC)
+        return datetime.datetime.fromisoformat(self.get_value(MINUTES, LAST_UPDATE))
 
     @property
     def is_minutes_total_supported(self):
@@ -165,9 +159,7 @@ class MeinVodafoneContract:
     @property
     def sms_remaining_last_update(self):
         """Return remaining sms for the plan last update timestamp."""
-        return datetime.datetime.strptime(
-            self.get_value(SMS, LAST_UPDATE), "%Y-%m-%dT%H:%M:%S"
-        ).replace(tzinfo=datetime.UTC)
+        return datetime.datetime.fromisoformat(self.get_value(SMS, LAST_UPDATE))
 
     @property
     def is_sms_remaining_supported(self):
@@ -185,9 +177,7 @@ class MeinVodafoneContract:
     @property
     def sms_used_last_update(self):
         """Return used sms for the plan last update timestamp."""
-        return datetime.datetime.strptime(
-            self.get_value(SMS, LAST_UPDATE), "%Y-%m-%dT%H:%M:%S"
-        ).replace(tzinfo=datetime.UTC)
+        return datetime.datetime.fromisoformat(self.get_value(SMS, LAST_UPDATE))
 
     @property
     def is_sms_used_supported(self):
@@ -205,9 +195,7 @@ class MeinVodafoneContract:
     @property
     def sms_total_last_update(self):
         """Return total sms for the plan last update timestamp."""
-        return datetime.datetime.strptime(
-            self.get_value(SMS, LAST_UPDATE), "%Y-%m-%dT%H:%M:%S"
-        ).replace(tzinfo=datetime.UTC)
+        return datetime.datetime.fromisoformat(self.get_value(SMS, LAST_UPDATE))
 
     @property
     def is_sms_total_supported(self):
@@ -235,9 +223,7 @@ class MeinVodafoneContract:
     @property
     def data_remaining_last_update(self):
         """Return remaining data for the plan last update timestamp."""
-        return datetime.datetime.strptime(
-            self.get_value(DATA, LAST_UPDATE), "%Y-%m-%dT%H:%M:%S"
-        ).replace(tzinfo=datetime.UTC)
+        return datetime.datetime.fromisoformat(self.get_value(DATA, LAST_UPDATE))
 
     @property
     def is_data_remaining_supported(self):
@@ -255,9 +241,7 @@ class MeinVodafoneContract:
     @property
     def data_used_last_update(self):
         """Return used data for the plan last update timestamp."""
-        return datetime.datetime.strptime(
-            self.get_value(DATA, LAST_UPDATE), "%Y-%m-%dT%H:%M:%S"
-        ).replace(tzinfo=datetime.UTC)
+        return datetime.datetime.fromisoformat(self.get_value(DATA, LAST_UPDATE))
 
     @property
     def is_data_used_supported(self):
@@ -275,9 +259,7 @@ class MeinVodafoneContract:
     @property
     def data_total_last_update(self):
         """Return total data for the plan last update timestamp."""
-        return datetime.datetime.strptime(
-            self.get_value(DATA, LAST_UPDATE), "%Y-%m-%dT%H:%M:%S"
-        ).replace(tzinfo=datetime.UTC)
+        return datetime.datetime.fromisoformat(self.get_value(DATA, LAST_UPDATE))
 
     @property
     def is_data_total_supported(self):


### PR DESCRIPTION
**1. feat: Add support for CallYa (prepaid) contracts**

The Vodafone API returns a different JSON structure for prepaid (CallYa) contracts compared to postpaid contracts when using the same `unbilledUsage` endpoint.

This change updates the `get_contract_usage` method to handle both response types, enabling support for CallYa users.

Key changes:
- The parsing of the `billDetails` object is now conditional, preventing errors for prepaid contracts which lack this object.
- The integration now recognizes container names specific to CallYa contracts (e.g., `D_EU_DATA`).
- The code prioritizes parsing the `vluxgateAgg` object for aggregated usage data found in CallYa responses, while maintaining the previous parsing logic for backward compatibility with postpaid contracts.

**2. fix: Correct timestamp parsing and data handling for CallYa**

This fix addresses a `ValueError` that occurred when parsing timestamps from the Vodafone API for CallYa contracts. It also fixes a bug where the `last_update` time was missing for aggregated sensor data.

Key changes:
- Replaced all `strptime` calls in `MeinVodafoneContract.py` with `fromisoformat` to correctly handle ISO 8601 timestamps with millisecond precision and timezone offsets.
- Corrected the logic in `MeinVodafoneAPI.py` to ensure the `lastUpdateDate` is properly extracted and associated with aggregated data for CallYa contracts.