### PR TITLE
v1.2.3

### DIFF
--- a/custom_components/meinvodafone/MeinVodafoneAPIPool.py
+++ b/custom_components/meinvodafone/MeinVodafoneAPIPool.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import time
 
 from .MeinVodafoneAPI import MeinVodafoneAPI
+from .const import (
+    MIN_LOGIN_DELAY,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -15,6 +20,8 @@ class MeinVodafoneAPIPool:
     def __init__(self) -> None:
         """Initialize the API pool."""
         self._sessions: dict[str, MeinVodafoneAPI] = {}
+        self._login_locks: dict[str, asyncio.Lock] = {}
+        self._last_login_time: dict[str, float] = {}
 
     def get_or_create(self, username: str, password: str) -> MeinVodafoneAPI:
         """Get existing API session or create new one.
@@ -33,7 +40,54 @@ class MeinVodafoneAPIPool:
         _LOGGER.debug("Creating new API session for user: %s", username)
         api = MeinVodafoneAPI(username, password)
         self._sessions[username] = api
+
+        # Initialize lock for this username
+        if username not in self._login_locks:
+            self._login_locks[username] = asyncio.Lock()
+
         return api
+
+    async def ensure_authenticated(self, api: MeinVodafoneAPI, username: str) -> bool:
+        """Ensure API is authenticated, login only if needed.
+
+        Args:
+            api: The API instance to check/authenticate
+            username: The username (used for tracking)
+
+        Returns:
+            True if authenticated, False otherwise
+        """
+        # Get or create lock for this username
+        if username not in self._login_locks:
+            self._login_locks[username] = asyncio.Lock()
+
+        lock = self._login_locks[username]
+
+        async with lock:
+            # Check if already authenticated
+            if api.is_authenticated:
+                _LOGGER.debug("API session already authenticated for %s", username)
+                return True
+
+            # Check if we need to wait before next login
+            last_login = self._last_login_time.get(username, 0)
+            time_since_last = time.time() - last_login
+
+            if time_since_last < MIN_LOGIN_DELAY:
+                delay = MIN_LOGIN_DELAY - time_since_last
+                _LOGGER.debug(
+                    "Rate limiting login for %s: waiting %.1f seconds", username, delay
+                )
+                await asyncio.sleep(delay)
+
+            # Perform login
+            _LOGGER.debug("Performing login for user: %s", username)
+            result = await api.login()
+
+            # Update last login time
+            self._last_login_time[username] = time.time()
+
+            return result
 
     async def close_all(self) -> None:
         """Close all API sessions in the pool."""
@@ -41,6 +95,8 @@ class MeinVodafoneAPIPool:
             _LOGGER.debug("Closing API session for user: %s", username)
             await api.close()
         self._sessions.clear()
+        self._login_locks.clear()
+        self._last_login_time.clear()
 
     async def remove(self, username: str) -> None:
         """Remove and close a specific API session.
@@ -52,3 +108,9 @@ class MeinVodafoneAPIPool:
             _LOGGER.debug("Removing API session for user: %s", username)
             await self._sessions[username].close()
             del self._sessions[username]
+
+        # Clean up locks and timing info
+        if username in self._login_locks:
+            del self._login_locks[username]
+        if username in self._last_login_time:
+            del self._last_login_time[username]

--- a/custom_components/meinvodafone/const.py
+++ b/custom_components/meinvodafone/const.py
@@ -8,6 +8,8 @@ MEINVODAFONE_API_POOL = "meinvodafone_api_pool"
 DEFAULT_UPDATE_INTERVAL = 15
 MAX_UPDATE_RETRY_COUNT = 2
 REQUEST_TIMEOUT = 10
+MIN_LOGIN_DELAY = 5
+API_TIMEOUT = 60  # seconds
 
 MINT_HOST = "https://www.vodafone.de/mint"
 API_HOST = "https://www.vodafone.de/api"

--- a/custom_components/meinvodafone/manifest.json
+++ b/custom_components/meinvodafone/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/stickpin/homeassistant-meinvodafone/issues",
   "requirements": [],
   "ssdp": [],
-  "version": "v1.2.2",
+  "version": "v1.2.3",
   "zeroconf": []
 }


### PR DESCRIPTION
### Change log:

feat: Add authentication state tracking and rate limiting for multi-contract setups

- Add `is_authenticated` flag to MeinVodafoneAPI to track login state
- Implement `ensure_authenticated()` method in APIPool with lock-based rate limiting
- Prevent concurrent login requests when multiple contracts use same credentials
- Add MIN_LOGIN_DELAY constant (5 seconds) to prevent API overload
- Call `ensure_authenticated()` before data fetch to reuse existing sessions
- Reduce login requests from N (per contract) to 1 (per username) on startup

Fixes issue where multiple contracts caused simultaneous login attempts, resulting in API errors (NullPointerException) and unnecessary authentication overhead.